### PR TITLE
Added ACE3 Snippets - Function Header and Settings Entry

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = crlf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This package offers syntax highlighting and auto-completion for SQF.
 
 ### Syntax highlighting
 
-We support syntax highlighting all Bohemia Interactive functions and script commands. Next to that, we also support both CBA functions and Macros as well as ACE3 project macros.
+We support syntax highlighting for all Bohemia Interactive functions and script commands. Next to that, we also support both CBA functions and Macros as well as ACE3 project macros.
 
 ![Syntax highlighting](https://raw.github.com/acemod/language-arma-atom/master/syntax_highlighting.png)
 

--- a/snippets/language-sqf.cson
+++ b/snippets/language-sqf.cson
@@ -25,11 +25,11 @@
     'prefix': 'ace_settings_entry'
     'body': """
       class GVAR(${1:name}) {
-        displayName = CSTRING(${2:stringDisplayName});
-        description = CSTRING(${3:stringDescription});
-        isClientSettable = ${4:[0/1]};
-        typeName = "${5:[BOOL/SCALAR/STRING/ARRAY/COLOR]]}";
-        value = ${6:[Number]};
+          displayName = CSTRING(${2:stringDisplayName});
+          description = CSTRING(${3:stringDescription});
+          isClientSettable = ${4:[0/1]};
+          typeName = "${5:[BOOL/SCALAR/STRING/ARRAY/COLOR]]}";
+          value = ${6:[Number]};
       };
     """
     'description': 'ACE_Settings Entry (without SCALAR values)'

--- a/snippets/language-sqf.cson
+++ b/snippets/language-sqf.cson
@@ -1,0 +1,36 @@
+'.source.sqf':
+  'ACE3 Function Header':
+    'prefix': 'ace_function_header'
+    'body': """
+      /*
+       * Author: ${1:[Name of Author(s)]}
+       * ${2:[Description]}
+       *
+       * Arguments:
+       * 0: ${3:Argument Name} <${4:TYPE}>
+       *
+       * Return Value:
+       * ${5:Return Name} <${6:TYPE}>
+       *
+       * Example:
+       * [${7:"example"}] call ace_${8:[module]}_fnc_${9:[functionName]}
+       *
+       * Public: ${10:[Yes/No]}
+       */
+      #include "script_component.hpp"
+    """
+    'description': 'Function Header per ACE3 guidelines.'
+    'descriptionMoreURL': 'http://ace3mod.com/wiki/development/coding-guidelines.html#3-1-function-definitions'
+  'ACE3 Settings Entry':
+    'prefix': 'ace_settings_entry'
+    'body': """
+      class GVAR(${1:name}) {
+        displayName = CSTRING(${2:stringDisplayName});
+        description = CSTRING(${3:stringDescription});
+        isClientSettable = ${4:[0/1]};
+        typeName = "${5:[BOOL/SCALAR/STRING/ARRAY/COLOR]]}";
+        value = ${6:[Number]};
+      };
+    """
+    'description': 'ACE_Settings Entry (without SCALAR values)'
+    'descriptionMoreURL': 'http://ace3mod.com/wiki/framework/settings.html'


### PR DESCRIPTION
ACE3 Function Header (`ace_function_header`) looks like:

```
/*
 * Author: [Name of Author(s)]
 * [Description]
 *
 * Arguments:
 * 0: Argument Name <TYPE>
 *
 * Return Value:
 * Return Name <TYPE>
 *
 * Example:
 * ["example"] call ace_[module]_fnc_[functionName]
 *
 * Public: [Yes/No]
 */
#include "script_component.hpp"
```

ACE3 Settings Entry (`ace_settings_entry`) looks like:

```
class GVAR(name) {
    displayName = CSTRING(stringDisplayName);
    description = CSTRING(stringDescription);
    isClientSettable = [0/1];
    typeName = "[BOOL/SCALAR/STRING/ARRAY/COLOR]]";
    value = [Number];
};
```

Also added .editorconfig file for anyone that uses it.
