### PR TITLE
Open RPT-file command

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,0 +1,1 @@
+module.exports = require "./lib/rptfile"

--- a/lib/rptfile.coffee
+++ b/lib/rptfile.coffee
@@ -9,7 +9,7 @@ module.exports =
   config:
     appDataFolder:
       title: "Arma 3 AppData Folder",
-      description: "Location of the Arma 3 Application Data Folder. (Location of rpt-Files)",
+      description: "Location of the Arma 3 Application Data Folder (location of RPT files)",
       type: "string",
       default: "%localappdata%\\Arma 3\\"
 

--- a/lib/rptfile.coffee
+++ b/lib/rptfile.coffee
@@ -1,0 +1,44 @@
+{CompositeDisposable} = require 'atom'
+fs = require 'fs'
+path = require 'path'
+process = require 'process'
+
+module.exports =
+  subscriptions: null
+
+  config:
+    appDataFolder:
+      title: "Arma 3 AppData Folder",
+      description: "Location of the Arma 3 Application Data Folder. (Location of rpt-Files)",
+      type: "string",
+      default: "%localappdata%\\Arma 3\\"
+
+  activate: ->
+    @subscriptions = new CompositeDisposable
+    @subscriptions.add atom.commands.add 'atom-workspace',
+      'language-arma-atom:open-rpt-file': => @open()
+
+  deactivate: ->
+    @subscriptions.dispose()
+
+  getLatestRptFile: (dir) ->
+    (fs.readdirSync dir
+      .filter (v) ->
+        '.rpt' == path.extname (v)
+      .map (v) ->
+        return {
+        name: dir+v,
+        time: fs.statSync(dir + v).mtime.getTime()}
+      .sort (a, b) -> b.time - a.time
+      .map (v) -> v.name)[0]
+
+
+
+  open: ->
+    p = atom.config.get('language-arma-atom.appDataFolder').replace /%([^%]+)%/g, (_,n) -> process.env[n]
+    atom.workspace.open(@getLatestRptFile p).done (rptView) ->
+      rptView.moveToBottom()
+      rptView.scrollToBottom()
+      rptView.getBuffer().onDidReload (e) ->
+        rptView.moveToBottom()
+        rptView.scrollToBottom()

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "ace3"
   ],
   "activationCommands": {
-    "atom-workspace": "language-arma-atom:toggle"
+    "atom-workspace": [
+      "language-arma-atom:toggle",
+      "language-arma-atom:open-rpt-file"
+    ]
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Now a clean PR for this feature.

I added the command `language-arma-atom:open-rpt-file`, which opens the rpt-file and automatically scrolls down. The default rpt-file folder is `%localappdata%\\Arma 3\\` which can be set in the package settings panel. I will add this functionality to a toolbar system called [`tool-bar`](https://atom.io/packages/tool-bar), which seems to be very easy. What is your opinion about that?
