### PR TITLE
Added pre-processor definitions to ArmaConfig snippets

### DIFF
--- a/grammars/cfg.json
+++ b/grammars/cfg.json
@@ -4,7 +4,9 @@
   "fileTypes": [
     "cfg",
     "sqm",
-    "ext"
+    "ext",
+    "cpp",
+    "hpp"
   ],
   "patterns": [
     {

--- a/settings/language-sqf-macros-ace3.json
+++ b/settings/language-sqf-macros-ace3.json
@@ -1,5 +1,5 @@
 {
-  ".source.sqf, .source.arma.cfg, .source.cpp, .source.hpp, .source.ext": {
+  ".source.sqf, .source.arma.cfg, .source.cpp, .source.hpp": {
     "autocomplete": {
       "symbols": {
         "macro-ace3": {

--- a/settings/language-sqf-macros-cba.json
+++ b/settings/language-sqf-macros-cba.json
@@ -1,5 +1,5 @@
 {
-  ".source.sqf, .source.arma.cfg, .source.cpp, .source.hpp, .source.ext": {
+  ".source.sqf, .source.arma.cfg, .source.cpp, .source.hpp": {
     "autocomplete": {
       "symbols": {
         "macro-cba": {

--- a/settings/language-sqf-native.json
+++ b/settings/language-sqf-native.json
@@ -1,20 +1,4 @@
 {
-  ".source.sqf, .source.arma.cfg, .source.cpp, .source.hpp, .source.ext": {
-    "autocomplete": {
-      "symbols": {
-        "builtin": {
-          "typePriority": 0,
-          "suggestions": [
-            "#include",
-            "#define",
-            "#undef",
-            "#ifdef",
-            "#endif"
-          ]
-        }
-      }
-    }
-  },
   ".source.sqf": {
     "autocomplete": {
       "symbols": {

--- a/snippets/language-sqf-ace3.json
+++ b/snippets/language-sqf-ace3.json
@@ -70,7 +70,7 @@
   },
 
 
-  ".source.arma.cfg, .source.cpp, .source.hpp, .source.ext": {
+  ".source.arma.cfg, .source.cpp, .source.hpp": {
     "ACE3 Settings Entry": {
       "prefix": "settings_entry_ace",
       "body": "class GVAR(${1:name}) {\n    displayName = CSTRING(${2:stringDisplayName});\n    description = CSTRING(${3:stringDescription});\n    category = CSTRING(${4:category});\n    isClientSettable = ${5:[0/1]};\n    typeName = \"${6:[BOOL/SCALAR/STRING/ARRAY/COLOR]}\";\n    value = ${7:[NUMBER]};\n};",

--- a/snippets/language-sqf-native.json
+++ b/snippets/language-sqf-native.json
@@ -72,5 +72,50 @@
       "description": "Loop while condition is true",
       "descriptionMoreURL": "https://community.bistudio.com/wiki/while"
     }
+  },
+
+  ".source.sqf, .source.arma.cfg": {
+    "#include \"\"": {
+      "prefix": "include",
+      "body": "#include \"${1:.hpp}\"",
+      "description": "Inserts the code from target file",
+      "descriptionMoreURL": "https://community.bistudio.com/wiki/PreProcessor_Commands#.23include"
+    },
+    "#include <>": {
+      "prefix": "Include",
+      "body": "#include <${1:.hpp}>",
+      "description": "Inserts the code from target file",
+      "descriptionMoreURL": "https://community.bistudio.com/wiki/PreProcessor_Commands#.23include"
+    },
+    "#define": {
+      "prefix": "define",
+      "body": "#define ${1:keyword} ${2:value}",
+      "description": "Defines a keyword and assigns a definition to it",
+      "descriptionMoreURL": "https://community.bistudio.com/wiki/PreProcessor_Commands#.23define"
+    },
+    "#undef": {
+      "prefix": "undef",
+      "body": "#undef ${1:keyword}",
+      "description": "Deletes a macro previously set by #define",
+      "descriptionMoreURL": "https://community.bistudio.com/wiki/PreProcessor_Commands#.23undef"
+    },
+    "#ifdef": {
+      "prefix": "ifdef",
+      "body": "#ifdef ${1:keyword}\n    ${2:text}\n#endif",
+      "description": "Defines if another macro already defined",
+      "descriptionMoreURL": "https://community.bistudio.com/wiki/PreProcessor_Commands#.23ifdef"
+    },
+    "#ifndef": {
+      "prefix": "ifndef",
+      "body": "#ifndef ${1:keyword}\n    ${2:text}\n#endif",
+      "description": "Defines if another macro is not yet defined",
+      "descriptionMoreURL": "https://community.bistudio.com/wiki/PreProcessor_Commands#.23ifndef"
+    },
+    "#else": {
+      "prefix": "else",
+      "body": "#else\n    ${1:text}",
+      "description": "Used inside #ifndef when another macro is defined",
+      "descriptionMoreURL": "https://community.bistudio.com/wiki/PreProcessor_Commands#.23else"
+    }
   }
 }


### PR DESCRIPTION
And added `.cpp` and `.hpp` to ArmaConfig file types.

I checked C++ and it only has `#include` and `#ifndef ...#define ...` snippets, possibly we should just copy them from there. That's also the reason I didn't add cpp and hpp file types to them as it would duplicate them when C++ language is selected.

Also removed `.ext` as it's part of `.arma.cfg`, left `.cpp` and `.hpp` for C++ compatibility.

Fixes #24 
