### PR TITLE
Fix spec package activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "activationCommands": {
     "atom-workspace": [
+      "language-arma-atom:toggle",
       "language-arma-atom:open-latest-RPT-file",
       "language-arma-atom:build-dev",
       "language-arma-atom:build-release"

--- a/spec/sqf-spec.coffee
+++ b/spec/sqf-spec.coffee
@@ -1,28 +1,24 @@
-util = require('util')
-
 describe "SQF grammar", ->
-  grammar = null
-  workspaceElement = atom.views.getView(atom.workspace)
+  [workspaceElement, grammar] = []
 
-#  executeCommand = (callback) ->
-#    atom.commands.dispatch(workspaceElement, 'language-arma-atom:toggle')
-#    waitsForPromise ->
-#      activationPromise
-#    grammar = atom.grammars.grammarForScopeName("source.sqf")
-#    runs(callback)
+  beforeEach ->
+    workspaceElement = atom.views.getView(atom.workspace)
 
-#  beforeEach ->
-    ## active our sqf package
-#    activationPromise  = atom.packages.activatePackage("language-arma-atom")
+    waitsForPromise ->
+      Promise.all [
+        atom.packages.activatePackage("language-arma-atom")
+        atom.commands.dispatch workspaceElement, "language-arma-atom:toggle"
+      ]
 
-#  it "parses the grammar", ->
-#    executeCommand >
-#      expect(grammar).toBeDefined()
-#      expect(grammar.scopeName).toBe "source.sqf"
+    runs ->
+      grammar = atom.grammars.grammarForScopeName("source.sqf")
 
-#  it "tokenizes multi-line strings", ->
-#    executeCommand >
-#      tokens = grammar.tokenizeLines('"12"')
-#      expect(tokens[0][0].value).toBe '"'
-#      expect(tokens[0][1].value).toBe '12'
-#      expect(tokens[0][2].value).toBe '"'
+  it "parses the grammar", ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe "source.sqf"
+
+  it "tokenizes multi-line strings", ->
+    tokens = grammar.tokenizeLines('"12"')
+    expect(tokens[0][0].value).toBe '"'
+    expect(tokens[0][1].value).toBe '12'
+    expect(tokens[0][2].value).toBe '"'


### PR DESCRIPTION
Continuation of #51 

When `activationCommands` are used activating the package doesn't work the same way, source: https://discuss.atom.io/t/need-help-with-writing-specs-around-package-activation/15053/2
