### PR TITLE
Add keybinds for latest RPT file and build dev

### DIFF
--- a/keymaps/language-arma-atom.cson
+++ b/keymaps/language-arma-atom.cson
@@ -1,0 +1,3 @@
+'atom-workspace':
+  'alt-a r': 'language-arma-atom:open-latest-RPT-file'
+  'alt-a b': 'language-arma-atom:build-dev'


### PR DESCRIPTION
I was looking into ways to speed up some of the dev stuff, and while setting up macros on my keyboard I thought why not add keybinds to this package for easy access.

Keybinded commands:
- Open Latest RPT File (`alt+a -> r`)
- Build Dev (`alt+a -> b`)

Commands can be modified using local settings that Atom has, most important is probably opening latest RPT file. It is overall much faster than opening command pallet and typing out part of the command word.
