### PR TITLE
add sqe (arma3 editor compositions) to list of file types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 npm-debug.log
 node_modules
 *.sqf
+*.sqe
 *.sqm
 *.cfg
 *.ext

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This packages adds syntax highlighting and auto-completions for SQF files in Ato
 
 Support for the following file types used by the Real Virtuality engine has been added:
 - sqf
+- sqe
 - sqm
 - cpp
 - hpp

--- a/grammars/cfg.json
+++ b/grammars/cfg.json
@@ -3,6 +3,7 @@
   "name": "Arma Config",
   "fileTypes": [
     "cfg",
+    "sqe",
     "sqm",
     "ext",
     "cpp",


### PR DESCRIPTION
Arma3 editor saves compositions as sqe files - which are basically just sqm snippets.
