### PR TITLE
Add syntax-highlighting for localized strings

### DIFF
--- a/grammars/cfg.json
+++ b/grammars/cfg.json
@@ -22,6 +22,10 @@
       "end": "\""
     },
     {
+      "name": "string.localized.sqf",
+      "match": "\\$STR[a-zA-Z_]*"
+    },
+    {
       "include": "source.cpp"
     }
   ]


### PR DESCRIPTION
Add syntax-highlighting for localized strings in configs
May want a different class (color) for these. But if using a different color than strings one might want to use the same color in sqf localize "STR_XXX"
