### PR TITLE
Add support for .inc files

### DIFF
--- a/grammars/cfg.json
+++ b/grammars/cfg.json
@@ -8,7 +8,8 @@
     "ext",
     "cpp",
     "hpp",
-    "h"
+    "h",
+    "inc"
   ],
   "patterns": [
     {


### PR DESCRIPTION
ArmA 3 uses .inc files as a way to create "include" file/library that shouldn't be merged into the config file. This is similar to ACE/CBA's script component files. This PR simply allows the .inc files to be treated as a ArmA configuration file.